### PR TITLE
Fix duplicate title check

### DIFF
--- a/quiz/src/main/java/com/dilshan/quiz/Service/QuizService.java
+++ b/quiz/src/main/java/com/dilshan/quiz/Service/QuizService.java
@@ -44,11 +44,11 @@ public class QuizService {
             throw new IllegalArgumentException("Number of questions must be greater than zero. Please provide a valid number.");
         }
 
-        String checkCategory = quizRepository.checkTitle(title);
+        String existingTitle = quizRepository.checkTitle(title);
 
         //get question ids by number of questions and category
         List<Integer> questions = quizInterface.findQuestionByCategory(category, noOfQuestions).getBody();
-        if(!checkCategory.isEmpty()){
+        if (existingTitle != null && !existingTitle.isEmpty()) {
             throw new TitleIsAlreadyAvailable("Provided title is already available. Please enter a new, unique title.");
         }
         if(questions == null || questions.isEmpty()){


### PR DESCRIPTION
## Summary
- improve variable naming in QuizService
- strengthen duplicate title check

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68499fc0c9fc832dae21dbd5e91e3776