### PR TITLE
Update QuizService header comment

### DIFF
--- a/quiz/src/main/java/com/dilshan/quiz/Service/QuizService.java
+++ b/quiz/src/main/java/com/dilshan/quiz/Service/QuizService.java
@@ -1,6 +1,6 @@
 // QuizService handles the business logic for quiz management, including creation, retrieval, and scoring.
 // It interacts with the QuizRepository for database operations and QuizInterface for external service calls.
-// All exceptions are custom and provide clear error messages for the API layer.
+// The service uses custom exceptions and IllegalArgumentException to provide clear error messages for the API layer.
 package com.dilshan.quiz.Service;
 
 import com.dilshan.quiz.Exception.NotFoundQuestionException;


### PR DESCRIPTION
## Summary
- clarify that QuizService uses both custom exceptions and `IllegalArgumentException` in its header comment

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68499fd3aae0832da0e2f76e940bf7c9